### PR TITLE
Bump Python to 3.12 in bibliometrics workflow

### DIFF
--- a/.github/workflows/bibliometrics.yml
+++ b/.github/workflows/bibliometrics.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: 'Download and run bibliometrics'
       run: |


### PR DESCRIPTION
## Summary
Bump Python to 3.12 in bibliometrics workflow

